### PR TITLE
Arilivigni/ai skills post update

### DIFF
--- a/S4-SeasonOfAgents/build-applications-w-github-copilot-agent-mode.md
+++ b/S4-SeasonOfAgents/build-applications-w-github-copilot-agent-mode.md
@@ -72,10 +72,9 @@ By the end of this session, participants will understand:
   - [Microsoft AI SKills Fest - Build applications with GitHub Copilot agent mode](../assets/build_applications_w_github_copilot/Microsoft%20AI%20SKills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode.pptx)
 - Videos
   - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.mp4)
-  - [AI Skills Fest - Train-the-Trainer - Build Applications with GitHub Copilot Agent Mode](https://aka.ms/AAva08z)
+  - [AI Skills Fest - live event video - Build Applications with GitHub Copilot Agent Mode](https://www.youtube.com/live/dLFlXzJJVoU?si=R3GiVc7zziOR1xBD)
   - Video summaries
     - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.pdf)
-    - [AI Skills Fest - Train-the-Trainer - Build Applications with GitHub Copilot Agent Mode](../assets/build_applications_w_github_copilot/AI%20Skills%20Fest%20-%20Train-the-Trainer%20-%20Build%20Applications%20with%20GitHub%20Copilot%20Agent%20Mode.pdf)
   - Transcripts
     - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.srt)
-    - [AI Skills Fest - Train-the-Trainer - Build Applications with GitHub Copilot Agent Mode](../assets/build_applications_w_github_copilot/AI%20Skills%20Fest%20-%20Train-the-Trainer%20-%20Build%20Applications%20with%20GitHub%20Copilot%20Agent%20Mode.srt)
+

--- a/S4-SeasonOfAgents/build-applications-w-github-copilot-agent-mode.md
+++ b/S4-SeasonOfAgents/build-applications-w-github-copilot-agent-mode.md
@@ -72,9 +72,9 @@ By the end of this session, participants will understand:
   - [Microsoft AI SKills Fest - Build applications with GitHub Copilot agent mode](../assets/build_applications_w_github_copilot/Microsoft%20AI%20SKills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode.pptx)
 - Videos
   - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.mp4)
-  - [AI Skills Fest - live event video - Build Applications with GitHub Copilot Agent Mode](https://www.youtube.com/live/dLFlXzJJVoU?si=R3GiVc7zziOR1xBD)
+  - [AI Skills Fest - live reactor series event video - Build Applications with GitHub Copilot Agent Mode](https://www.youtube.com/watch?v=dLFlXzJJVoU)
   - Video summaries
-    - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.pdf)
+    - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview - video summary](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.pdf)
   - Transcripts
-    - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.srt)
+    - [Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode - slides overview - transcript](../assets/build_applications_w_github_copilot/Microsoft%20AI%20Skills%20Fest%20-%20Build%20applications%20with%20GitHub%20Copilot%20agent%20mode%20-%20slides%20overview.srt)
 


### PR DESCRIPTION
This pull request includes updates to the `S4-SeasonOfAgents/build-applications-w-github-copilot-agent-mode.md` file to replace outdated video and document links with new ones. The changes ensure that the latest resources are referenced for the session.

Changes to video links and summaries:

* Replaced the outdated "AI Skills Fest - Train-the-Trainer" video link with a new link to the "AI Skills Fest - live reactor series event video" on YouTube.
* Updated the video summary and transcript links to include more descriptive filenames, specifically for the "Microsoft AI Skills Fest - Build applications with GitHub Copilot agent mode" content.